### PR TITLE
Separating jira data from user data about versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ Run `yarn install` in the root directory.
 
 If the first time installing, create a `data` directory on the root directory.
 
+Copy the `./.env.sample` file to `./.env` and fill in settings as needed.
+
 #### Running the app locally
 
 Concurrently, in separate consoles, run:


### PR DESCRIPTION
Information attached to sprints comes from separate files instead of main jira files.  This reduces filesystem access needed for when there are many many revisions.